### PR TITLE
Persist the Preview URL for future jobs

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -97,6 +97,12 @@ jobs:
             echo "export CONTAINER=$CIRCLE_PROJECT_REPONAME-\$BRANCH" >> $CIRCLE_BUILD_NUM
             echo "export DIRECTORY=$CIRCLE_PROJECT_REPONAME/\$BRANCH" >> $CIRCLE_BUILD_NUM
       - run:
+          name: Write Preview URL to a persisted file
+          command: |
+            source $CIRCLE_BUILD_NUM
+            mkdir -p workspace
+            echo "https://$SUBDOMAIN.<< parameters.domain >>" > workspace/preview-url
+      - run:
           name: Notify Preview Deploy Started
           command: |
             source $CIRCLE_BUILD_NUM
@@ -141,3 +147,7 @@ jobs:
             ssh << parameters.user >>@<< parameters.server >> "docker ps | grep $CIRCLE_PROJECT_REPONAME | grep -vE '`cat grep_regex`'" | awk '{print $2}' > old_containers
             ssh << parameters.user >>@<< parameters.server >> "docker rm -f "`cat old_containers`""
             ssh << parameters.user >>@<< parameters.server >> "rm -fr "`cat old_containers | sed "s/$CIRCLE_PROJECT_REPONAME-/$CIRCLE_PROJECT_REPONAME\//g"`""
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - preview-url


### PR DESCRIPTION
Ref #2 

Having the Preview URL available could be useful to run other checks on the Preview, for example an a11y audit.

Here's how to use the persisted file that contains the URL into another job:

```yaml
  steps:
    - attach_workspace:
        # Must be absolute path or relative path from working_directory
        at: /tmp/workspace

    - run: |
        if [[ `cat /tmp/workspace/preview-url` == "http://preview-url.com" ]]; then
          echo "It worked!";
        else
          echo "Nope!"; exit 1
        fi
```

Of course the job that wants to use the Preview URL needs to require
this orb to run into a previous step before it to start (using require).

Here's more info:

https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs