### PR TITLE
Add metadata for pull-request, branch and subdomain to docker container

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -120,7 +120,7 @@ jobs:
           name: Build Docker Image On Docker Server
           command: |
             source $CIRCLE_BUILD_NUM
-            ssh << parameters.user >>@<< parameters.server >> "cd $DIRECTORY && << parameters.fetch_seed_data_command >> && docker build -t $CONTAINER --build-arg SUBDOMAIN=$SUBDOMAIN --file=<< parameters.dockerfile >> ."
+            ssh << parameters.user >>@<< parameters.server >> "cd $DIRECTORY && << parameters.fetch_seed_data_command >> && docker build --label \"pull-request=${CIRCLE_PULL_REQUEST##*/}\" --label \"branch=$CIRCLE_BRANCH\" --label \"subdomain=$SUBDOMAIN\" -t $CONTAINER --build-arg SUBDOMAIN=$SUBDOMAIN --file=<< parameters.dockerfile >> ."
       - run:
           name: Run Docker Container On Docker Server
           command: |


### PR DESCRIPTION
This PR adds three labels `pull-request`, `branch` and `subdomain` to the preview container.
In this way we can inspect the labels to obtain these informations back using:

```
docker inspect --format '{{ index .Config.Labels "pull-request" }}' container_id
docker inspect --format '{{ index .Config.Labels "branch" }}' container_id
docker inspect --format '{{ index .Config.Labels "subdomain" }}' container_id
```

**Note**: to get the PR number I used the `$CIRCLE_PULL_REQUEST` that contains the full URL of the associated pull request and the bash's built-in parameter substitution `${var##Pattern}`. The way this works is by removing a prefix that greedily matches `*/` (which is what the `##` operator does) because the PR number is the last part of the URL. 
E.g. `https://github.com/nebulab/circleci-orbs-feature-branch-preview/pull/4`