### PR TITLE
Persist the old preview URLs for future jobs

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -87,6 +87,9 @@ jobs:
       - checkout
       - add_ssh_keys
       - run:
+          name: Install jq package
+          command: sudo apt-get install jq
+      - run:
           name: Add Docker Server To Known SSH Hosts
           command: ssh-keyscan -H << parameters.server >> >> ~/.ssh/known_hosts
       - run:

--- a/source.yml
+++ b/source.yml
@@ -148,9 +148,11 @@ jobs:
             set +e
             ssh << parameters.user >>@<< parameters.server >> "docker ps | grep $CIRCLE_PROJECT_REPONAME | head -n << parameters.fresh_containers_count >>" | awk '{ print $1 }' | tr '\n' '|' | sed 's/|$/\n/' > grep_regex
             ssh << parameters.user >>@<< parameters.server >> "docker ps | grep $CIRCLE_PROJECT_REPONAME | grep -vE '`cat grep_regex`'" | awk '{print $2}' > old_containers
+            ssh << parameters.user >>@<< parameters.server >> "docker inspect "`cat old_containers`"" | jq 'map(select(.Config.Labels["pull-request"])) | map({key: .Config.Labels["pull-request"], value: {branch: .Config.Labels["branch"], preview_url: "https://\(.Config.Labels["subdomain"]).<< parameters.domain >>"}}) | from_entries' > workspace/deleted-previews.json
             ssh << parameters.user >>@<< parameters.server >> "docker rm -f "`cat old_containers`""
             ssh << parameters.user >>@<< parameters.server >> "rm -fr "`cat old_containers | sed "s/$CIRCLE_PROJECT_REPONAME-/$CIRCLE_PROJECT_REPONAME\//g"`""
       - persist_to_workspace:
           root: workspace
           paths:
             - preview-url
+            - deleted-previews.json


### PR DESCRIPTION
This uses the labels added in #4 to generate and persist a json file with a list of previews info associated with the containers removed during the current orb execution. The file format is something like:

```
{
  "PR_NUMBER": {
     "preview_url": "https://SUBDOMAIN.DOMAIN",
     "branch": "BRANCH"
  }
}
```

This adopts the same approach used in #3, so the way of retrieving the persisted file is the same:

```
  steps:
    - attach_workspace:
        # Must be absolute path or relative path from working_directory
        at: /tmp/workspace

    - run: |
        cat /tmp/workspace/deleted-previews.json
```

To generate the json file it uses `docker inspect` to retrieve the containers info in a json format and `jq` to parse this info:

```
# This selects only the containers with a label named `pull-request`
map(select(.Config.Labels["pull-request"]))

# This maps the container info returned by `docker inspect` into an array of
# `{"key": "PR_NUMBER", "value": {"branch": "BRANCH", "preview_url": "PREVIEW_URL"}}`
map({
  key: .Config.Labels["pull-request"],
  value: {
    branch: .Config.Labels["branch"],
    preview_url: "https://\(.Config.Labels["subdomain"]).<< parameters.domain >>"
  }
})

# Convert an array `[{"key": k, "value": v}]` into an object `{k: v}`
from_entries
```