### PR TITLE
Add a GIT_BRANCH env var for containers

### DIFF
--- a/src/jobs/preview.yml
+++ b/src/jobs/preview.yml
@@ -96,6 +96,7 @@ steps:
         -e VIRTUAL_HOST=$SUBDOMAIN.<< parameters.domain >> \
         -e LETSENCRYPT_HOST=$SUBDOMAIN.<< parameters.domain >> \
         -e LETSENCRYPT_EMAIL=<< parameters.letsencrypt_email >> \
+        -e GIT_BRANCH=$CIRCLE_BRANCH \
         $CONTAINER"
   - run:
       name: Notify Preview Deploy Complete


### PR DESCRIPTION
This adds the branch in which CircleCI is building the preview container as an environment variable named `GIT_BRANCH`.

The environment variable will be passed to the container when calling `docker run` so that the container will get far more information about the context it's running in.

An example of when this could be useful: sending an exception notification service exceptions tagged differently depending on the container that raised them.