### PR TITLE
Execute the `docker rm` only if the `old_containers` file is not empty

### DIFF
--- a/src/jobs/preview.yml
+++ b/src/jobs/preview.yml
@@ -119,7 +119,7 @@ steps:
       command: |
         set +e
         ssh << parameters.user >>@<< parameters.server >> "docker ps --format "{{.Names}}" --filter "name=$CIRCLE_PROJECT_REPONAME" | tail +$((<< parameters.fresh_containers_count >> + 1))" > old_containers
-        ssh << parameters.user >>@<< parameters.server >> "docker rm -f "`cat old_containers`""
+        if [ -s old_containers ]; then ssh << parameters.user >>@<< parameters.server >> "docker rm -f "`cat old_containers`""; fi
   - persist_to_workspace:
       root: workspace
       paths:


### PR DESCRIPTION
When there aren't old previews to delete, the CI fails because the `old_containers` file is empty and the `docker rm` command returns the following error:

>"docker rm" requires at least 1 argument.

This PR adds a check that executes the `docker rm` command only if the `old_container` file exists and is not empty using the `-s` [conditional expression](https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html).